### PR TITLE
fix: adapt retrieving signature and port to namespaces

### DIFF
--- a/bind_port.sh
+++ b/bind_port.sh
@@ -28,10 +28,9 @@ fi
 ############### VARIABLES ###############
 CONFIG_DIR=/home/felipe/.config/pia_vpn
 CERT=$CONFIG_DIR/ca.rsa.4096.crt
-CURL_NETNS="ip netns exec $NETNS_NAME curl"
 
 ############### BINDING ###############
-bind_port_response="$($CURL_NETNS -Gs -m 5 \
+bind_port_response="$(ip netns exec "$NETNS_NAME" curl -Gs -m 5 \
   --connect-to "$PF_HOSTNAME::$PF_GATEWAY:" \
   --cacert "$CERT" \
   --data-urlencode "payload=${PAYLOAD}" \

--- a/port_forwarding.sh
+++ b/port_forwarding.sh
@@ -15,9 +15,8 @@ trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
 
 ############### FUNCTIONS ###############
 function get_signature_and_payload() {
-  [[ -n $DEBUG ]] && echo "Getting new signature..."
   local payload_and_signature
-  payload_and_signature="$(curl -s -m 5 \
+  payload_and_signature="$(ip netns exec "$NETNS_NAME" curl -s -m 5 \
     --connect-to "$PF_HOSTNAME::$PF_GATEWAY:" \
     --cacert "$CERT" \
     -G --data-urlencode "token=${PIA_TOKEN}" \
@@ -63,10 +62,10 @@ if [[ -f $PAYLOAD_FILE ]]; then
   # Check if port has expired. It expires in 2 months
   if ((  expires_at < $(date +%s) )); then
     [[ -n $DEBUG ]] && echo "Payload from file has expired"
-    PAYLOAD_AND_SIGNATURE=$(get_signature_and_payload)
+    PAYLOAD_AND_SIGNATURE="$(get_signature_and_payload)"
   fi
 else
-  PAYLOAD_AND_SIGNATURE=$(get_signature_and_payload)
+  PAYLOAD_AND_SIGNATURE="$(get_signature_and_payload)"
 fi
 [[ -n $DEBUG ]] && echo "Payload and signature: $PAYLOAD_AND_SIGNATURE"
 


### PR DESCRIPTION
The command wasn't being run inside the namespace and when running in
debug mode, extra text was being outputed which made an invalid JSON