### PR TITLE
fix: use a user define Home varialbe

### DIFF
--- a/get_port.sh
+++ b/get_port.sh
@@ -24,10 +24,9 @@ function check_tool() {
 }
 
 ############### VARIABLES ###############
-readonly version=1.0.0
+readonly version=1.0.1
 readonly payload_file="/opt/piavpn/etc/account.json"
-readonly transmission_config_dir="${HOME}/.config/transmission"
-readonly transmission_settings=${transmission_config_dir}/settings.json
+readonly transmission_settings="${_HOME:?Home directory is not known}/.config/transmission/settings.json"
 was_running=false
 
 ############### CHECKS ###############


### PR DESCRIPTION
When running under systemd, $HOME will point at root and we need it to point at a user's. We know need to pass a variable $_HOME to the script.